### PR TITLE
add update command

### DIFF
--- a/cmd/ctl/cmd/load.go
+++ b/cmd/ctl/cmd/load.go
@@ -1,4 +1,4 @@
-package load
+package cmd
 
 import (
 	"fmt"
@@ -6,7 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/happsie/fivem-loader/internal/setup"
+	"github.com/happsie/fivem-loader/internal"
+	"github.com/happsie/fivem-loader/internal/config"
 	"github.com/happsie/fivem-loader/internal/updater"
 	"github.com/urfave/cli/v2"
 )
@@ -21,7 +22,7 @@ func Load() cli.ActionFunc {
 		if github == "" || !strings.HasPrefix(github, "https://github.com") {
 			return fmt.Errorf("invalid github url")
 		}
-		config, err := setup.LoadConfig()
+		config, err := config.LoadConfig()
 		if err != nil {
 			return err
 		}
@@ -36,11 +37,11 @@ func Load() cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		err = scriptUpdater.Update(scriptName, github, selectedFolder, ctx.Bool("skip-cfg"))
+		err = scriptUpdater.Update(scriptName, github, selectedFolder, ctx.Bool("skip-cfg"), false)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Script installation complete")
+		fmt.Printf(internal.InfoColor, fmt.Sprintf("Installation of script [%s] complete\n", scriptName))
 		return nil
 	}
 }

--- a/cmd/ctl/cmd/loaded.go
+++ b/cmd/ctl/cmd/loaded.go
@@ -1,21 +1,22 @@
-package load
+package cmd
 
 import (
 	"fmt"
 
-	"github.com/happsie/fivem-loader/internal/setup"
+	"github.com/happsie/fivem-loader/internal"
+	"github.com/happsie/fivem-loader/internal/config"
 	"github.com/rodaine/table"
 	"github.com/urfave/cli/v2"
 )
 
 func Loaded() cli.ActionFunc {
 	return func(ctx *cli.Context) error {
-		conf, err := setup.LoadConfig()
+		conf, err := config.LoadConfig()
 		if err != nil {
 			return err
 		}
 		if len(conf.InstalledScripts) == 0 {
-			fmt.Println("No loaded scripts found")
+			fmt.Printf(internal.InfoColor, "No loaded scripts found")
 			return nil
 		}
 		tbl := table.New("Name", "Location", "Github")

--- a/cmd/ctl/cmd/prompt.go
+++ b/cmd/ctl/cmd/prompt.go
@@ -1,4 +1,4 @@
-package load
+package cmd
 
 import "github.com/manifoldco/promptui"
 

--- a/cmd/ctl/cmd/setup.go
+++ b/cmd/ctl/cmd/setup.go
@@ -1,12 +1,13 @@
-package setup
+package cmd
 
 import (
+	"github.com/happsie/fivem-loader/internal/config"
 	"github.com/urfave/cli/v2"
 )
 
 func Setup() cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		path := ctx.String("server-data-path")
-		return CreateConfig(path)
+		return config.CreateConfig(path)
 	}
 }

--- a/cmd/ctl/cmd/unload.go
+++ b/cmd/ctl/cmd/unload.go
@@ -1,10 +1,11 @@
-package load
+package cmd
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/happsie/fivem-loader/internal/setup"
+	"github.com/happsie/fivem-loader/internal"
+	"github.com/happsie/fivem-loader/internal/config"
 	"github.com/thoas/go-funk"
 	"github.com/urfave/cli/v2"
 )
@@ -15,28 +16,28 @@ func Unload() cli.ActionFunc {
 		if scriptName == "" {
 			return fmt.Errorf("specify script name")
 		}
-		conf, err := setup.LoadConfig()
+		conf, err := config.LoadConfig()
 		if err != nil {
 			return err
 		}
-		script := funk.Find(conf.InstalledScripts, func(is setup.InstalledScript) bool {
+		script := funk.Find(conf.InstalledScripts, func(is config.InstalledScript) bool {
 			return is.Name == scriptName
 		})
 		if script == nil {
 			return fmt.Errorf("script not found")
 		}
-		err = os.RemoveAll(script.(setup.InstalledScript).Location)
+		err = os.RemoveAll(script.(config.InstalledScript).Location)
 		if err != nil {
 			return err
 		}
-		conf.InstalledScripts = funk.Filter(conf.InstalledScripts, func(is setup.InstalledScript) bool {
+		conf.InstalledScripts = funk.Filter(conf.InstalledScripts, func(is config.InstalledScript) bool {
 			return is.Name != scriptName
-		}).([]setup.InstalledScript)
+		}).([]config.InstalledScript)
 		err = conf.Save()
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Script unloaded [%s]", scriptName)
+		fmt.Printf(internal.InfoColor, fmt.Sprintf("Script unloaded [%s]", scriptName))
 		return nil
 	}
 }

--- a/cmd/ctl/cmd/update.go
+++ b/cmd/ctl/cmd/update.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/happsie/fivem-loader/internal"
+	"github.com/happsie/fivem-loader/internal/config"
+	"github.com/happsie/fivem-loader/internal/updater"
+	"github.com/thoas/go-funk"
+	"github.com/urfave/cli/v2"
+)
+
+func Update() cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		scriptName := ctx.String("script-name")
+		conf, err := config.LoadConfig()
+		if err != nil {
+			return err
+		}
+		if scriptName != "" {
+			is := funk.Find(conf.InstalledScripts, func(is config.InstalledScript) bool {
+				return is.Name == scriptName
+			})
+			if is == nil {
+				return fmt.Errorf("script with name %s not found", scriptName)
+			}
+			return update(conf.ServerDataPath, is.(config.InstalledScript))
+		}
+		encountedError := false
+		for _, is := range conf.InstalledScripts {
+			err := update(conf.ServerDataPath, is)
+			if err != nil {
+				encountedError = true
+				fmt.Printf(internal.ErrorColor, fmt.Sprintf("could not update script [%s]: %v\n", is.Name, err))
+			}
+		}
+		if encountedError {
+			fmt.Printf(internal.WarningColor, "Scripts updated. Some script(s) produced an error, please check console output\n")
+		} else {
+			fmt.Printf(internal.InfoColor, "All scripts updated\n")
+		}
+		return nil
+	}
+}
+
+func update(serverDataPath string, is config.InstalledScript) error {
+	scriptUpdater := updater.ScriptUpdater{
+		ServerDataPath: serverDataPath,
+	}
+	err := scriptUpdater.Update(is.Name, is.Github, is.ResourceFolder, is.SkippedConfig, true)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(internal.InfoColor, fmt.Sprintf("script updated [%s]\n", is.Name))
+	return nil
+}

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -4,8 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/happsie/fivem-loader/internal/load"
-	"github.com/happsie/fivem-loader/internal/setup"
+	"github.com/happsie/fivem-loader/cmd/ctl/cmd"
 	"github.com/urfave/cli/v2"
 )
 
@@ -22,7 +21,7 @@ func main() {
 						Required: true,
 					},
 				},
-				Action: setup.Setup(),
+				Action: cmd.Setup(),
 			},
 			{
 				Name:  "load",
@@ -48,12 +47,12 @@ func main() {
 						Value:    false,
 					},
 				},
-				Action: load.Load(),
+				Action: cmd.Load(),
 			},
 			{
 				Name:   "loaded",
 				Usage:  "List loaded scripts by FiveM Loader",
-				Action: load.Loaded(),
+				Action: cmd.Loaded(),
 			},
 			{
 				Name:  "unload",
@@ -66,7 +65,19 @@ func main() {
 						Required: true,
 					},
 				},
-				Action: load.Unload(),
+				Action: cmd.Unload(),
+			},
+			{
+				Name:  "update",
+				Usage: "Updates already installed script. If you do not specify a script name all scripts will be updated",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "script-name",
+						Aliases:  []string{"sn"},
+						Required: false,
+					},
+				},
+				Action: cmd.Update(),
 			},
 		},
 	}

--- a/internal/ansi_color.go
+++ b/internal/ansi_color.go
@@ -1,0 +1,9 @@
+package internal
+
+const (
+	InfoColor    = "\033[1;34m%s\033[0m"
+	NoticeColor  = "\033[1;36m%s\033[0m"
+	WarningColor = "\033[1;33m%s\033[0m"
+	ErrorColor   = "\033[1;31m%s\033[0m"
+	DebugColor   = "\033[0;36m%s\033[0m"
+)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-package setup
+package config
 
 import (
 	"encoding/json"
@@ -10,9 +10,11 @@ import (
 )
 
 type InstalledScript struct {
-	Name     string `json:"name"`
-	Github   string `json:"github"`
-	Location string `json:"location"`
+	Name           string `json:"name"`
+	Github         string `json:"github"`
+	Location       string `json:"location"`
+	ResourceFolder string `json:"resourceFolder"`
+	SkippedConfig  bool   `json:"skippedConfig"`
 }
 
 type Config struct {
@@ -56,7 +58,7 @@ func CreateConfig(path string) error {
 	}
 	defer f.Close()
 	conf := Config{
-		ServerDataPath: path,
+		ServerDataPath:   path,
 		InstalledScripts: []InstalledScript{},
 	}
 	err = conf.Save()

--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/happsie/fivem-loader/internal"
 )
 
 func DownloadZip(url string) (zipName string, err error) {
@@ -14,20 +16,18 @@ func DownloadZip(url string) (zipName string, err error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("Download complete [%s]\n", url)
+	fmt.Printf(internal.InfoColor, fmt.Sprintf("Download of resource [%s] complete\n", url))
 	defer resp.Body.Close()
 	fileName := getFileName()
 	out, err := createZipFile(fileName)
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("Zipfile created [%s]\n", fileName)
 	defer out.Close()
 	err = copyToFile(out, resp.Body)
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("Content written to file [%s]\n", fileName)
 	return fileName, nil
 }
 

--- a/internal/updater/unzip.go
+++ b/internal/updater/unzip.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/happsie/fivem-loader/internal"
 )
 
 func Unzip(resourceTargetDirectory, scriptName, zipName string) error {
@@ -17,15 +19,14 @@ func Unzip(resourceTargetDirectory, scriptName, zipName string) error {
 	defer archive.Close()
 
 	folderName := ""
+	fmt.Printf(internal.InfoColor, fmt.Sprintf("Installing script [%s] to %s\n", scriptName, resourceTargetDirectory))
 	for _, f := range archive.File {
 		if f.FileInfo().IsDir() && folderName == "" && strings.HasSuffix(f.Name, "-master/") {
 			folderName = f.Name
 		}
 		filePath := filepath.Join(resourceTargetDirectory, f.Name)
-		fmt.Printf("unzipping file %s\n", filePath)
 
 		if f.FileInfo().IsDir() {
-			fmt.Printf("creating directory %s", filePath)
 			err = os.MkdirAll(filePath, os.ModePerm)
 			if err != nil {
 				return err
@@ -53,6 +54,10 @@ func Unzip(resourceTargetDirectory, scriptName, zipName string) error {
 
 		dstFile.Close()
 		fileInArchive.Close()
+	}
+	err = os.RemoveAll(filepath.Join(resourceTargetDirectory, scriptName))
+	if err != nil {
+		return err
 	}
 	if folderName != "" {
 		err = os.Rename(filepath.Join(resourceTargetDirectory, folderName), filepath.Join(resourceTargetDirectory, scriptName))

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,5 +1,5 @@
 package updater
 
 type Updater interface {
-	Update(name, url, destinationFolder string, skipConfig bool) error
+	Update(name, url, destinationFolder string, skipConfig, forceUpdate bool) error
 }


### PR DESCRIPTION
Adds the update command that will update an already installed script. If no script name is specified, it will update all script. If the script was originally loaded with the skip config flag this command won't modify the `server.cfg`

## Update single script
```
update --script-name hello_world
```

## Update all installed scripts by FiveM Loader
```
update
```